### PR TITLE
added capability to restrict transport to specific level

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Valid meta characters in the datePattern are:
 
 ## Restrict to specific level
 
-Use boolean flag __restrictToLevel__ so you could create a lgo of only the specified level, default is false
+Use boolean flag __restrictToLevel__ so you could create a log of only the specified level, default is false
 example:
 ``` js
   new (winstonFileRotator)({

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Valid meta characters in the datePattern are:
 
 *Metadata:* Logged via util.inspect(meta);
 
+## Restrict to specific level
+
+Use boolean flag __restrictToLevel__ so you could create a lgo of only the specified level, default is false
+example:
+``` js
+  new (winstonFileRotator)({
+		name: 'info-log',
+		filename: "info.log",
+		level: 'info',
+		restrictToLevel : true
+	})
+```
+This will only write *info* log records to the file (no *warn* or *error* records will apear...)
+
+
 ##### LICENSE: MIT
 ##### AUTHOR: [Charlie Robbins](https://github.com/indexzero)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Valid meta characters in the datePattern are:
 Use boolean flag __restrictToLevel__ so you could create a log of only the specified level, default is false
 example:
 ``` js
-  new (winstonFileRotator)({
+  new (require('winston-daily-rotate-file'))({
 		name: 'info-log',
 		filename: "info.log",
 		level: 'info',

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ var DailyRotateFile = module.exports = function (options) {
   this.depth       = options.depth       || null;
   this.eol         = options.eol || os.EOL;
   this.maxRetries  = options.maxRetries || 2;
+  this.restrictToLevel   = options.restrictToLevel != null ? options.restrictToLevel : false;
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -150,6 +151,10 @@ DailyRotateFile.prototype.name = 'dailyRotateFile';
 //
 DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
   if (this.silent) {
+    return callback(null, true);
+  }
+  
+  if( this.restrictToLevel && level != this.level){
     return callback(null, true);
   }
 


### PR DESCRIPTION
Currently when specifying a level (such as 'info') any level that is stronger ('warn' or 'error') will also appear in that transport.

In this pull request I added the ability to add a Boolean flag that will give the developer the power to decide if the current file transport could be just for the specified level.

Boolean flag name is __restrictToLevel__

sample usage:
``` js
  new (require('winston-daily-rotate-file'))({
		name: 'info-log',
		filename: "info.log",
		level: 'info',
		restrictToLevel : true
	})
```

This will write to "info.log" file only __info__ log entries