### PR TITLE
Allow subdirectories to be specified in the datePattern option

### DIFF
--- a/index.js
+++ b/index.js
@@ -489,9 +489,9 @@ DailyRotateFile.prototype._createStream = function () {
 
       // mkdir if options.datePattern contains path delimiter
       if (target.indexOf('/') > -1) {
-        const targetpath = target.split('/');
+        var targetpath = target.split('/');
         for (var i = 1; i < targetpath.length; i++) {
-          const mkdirstep = path.join(self.dirname, targetpath.slice(0, i).join('/'));
+          var mkdirstep = path.join(self.dirname, targetpath.slice(0, i).join('/'));
           try {
             fs.mkdirSync(mkdirstep, '0744');
           } catch (e) {

--- a/index.js
+++ b/index.js
@@ -487,6 +487,21 @@ DailyRotateFile.prototype._createStream = function () {
         self._stream.destroySoon();
       }
 
+      // mkdir if options.datePattern contains path delimiter
+      if (target.indexOf('/') > -1) {
+        const targetpath = target.split('/');
+        for (var i = 1; i < targetpath.length; i++) {
+          const mkdirstep = path.join(self.dirname, targetpath.slice(0, i).join('/'));
+          try {
+            fs.mkdirSync(mkdirstep, '0744');
+          } catch (e) {
+            if (e.code !== 'EEXIST') {
+              throw e;
+            }
+          }
+        }
+      }
+
       self._size = size;
       self.filename = target;
       self._stream = fs.createWriteStream(fullname, self.options);


### PR DESCRIPTION
Supplying a datePattern value with /s in the pattern string will now create the hierarchy of directories to store the log file in instead of throwing an ENOENT.