### PR TITLE
Add localTime option

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ var DailyRotateFile = module.exports = function (options) {
   this.eol = options.eol || os.EOL;
   this.maxRetries = options.maxRetries || 2;
   this.prepend = options.prepend || false;
+  this.localTime = options.localTime || false;
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -122,13 +123,21 @@ var DailyRotateFile = module.exports = function (options) {
   }.bind(this)();
 
   var now = new Date();
-  this._year = now.getUTCFullYear();
-  this._month = now.getUTCMonth();
-  this._date = now.getUTCDate();
-  this._hour = now.getUTCHours();
-  this._minute = now.getUTCMinutes();
-  this._weekday = weekday[now.getUTCDay()];
-
+  if (this.localTime) {
+    this._year = now.getFullYear();
+    this._month = now.getMonth();
+    this._date = now.getDate();
+    this._hour = now.getHours();
+    this._minute = now.getMinutes();
+    this._weekday = weekday[now.getDay()];
+  } else {
+    this._year = now.getUTCFullYear();
+    this._month = now.getUTCMonth();
+    this._date = now.getUTCDate();
+    this._hour = now.getUTCHours();
+    this._minute = now.getUTCMinutes();
+    this._weekday = weekday[now.getUTCDay()];
+  }
   var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhM])\1?/g;
   var pad = function (val, len) {
     val = String(val);

--- a/test/simple.tests.js
+++ b/test/simple.tests.js
@@ -54,6 +54,17 @@ describe('winston/transports/daily-rotate-file', function () {
         expect(transport._getFilename()).to.equal('prepend-false.log.' + now);
       });
 
+      it('should have a proper filename when prepend option is false (localtime)', function () {
+        var now = moment().format('YYYY-MM-DD');
+        var transport = new DailyRotateFile({
+          filename: path.join(fixturesDir, 'prepend-false.log'),
+          localTime: true,
+          prepend: false
+        });
+
+        expect(transport._getFilename()).to.equal('prepend-false.log.' + now);
+      });
+
       it('should have a proper filename when prepend options is true', function () {
         var now = moment().utc().format('YYYY-MM-DD');
         var transport = new DailyRotateFile({


### PR DESCRIPTION
Our servers all run in a common timezone, all our logs are in a common timezone but this module is rolling files at 10am for us and datestamps in the logs change days as a result. 

Added a localTime option to the options hash during construction. Default is false so patch is backward compatible.