### PR TITLE
[fix] timestamp flag is always true

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ var DailyRotateFile = module.exports = function (options) {
   this.label = options.label || null;
   this.prettyPrint = options.prettyPrint || false;
   this.showLevel = options.showLevel === undefined ? true : options.showLevel;
-  this.timestamp = options.timestamp ? options.timestamp : true;
+  this.timestamp = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern ? options.datePattern : '.yyyy-MM-dd';
   this.depth = options.depth || null;
   this.eol = options.eol || os.EOL;


### PR DESCRIPTION
When we use winston-daily-rotate-file with timestamp, The timestamp flag is always 'true'.
So, I fixed this. Thx :)