### PR TITLE
Modifying the compressFile function to correct intermittent log file rotation crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -583,9 +583,13 @@ DailyRotateFile.prototype._createStream = function () {
 
         var inp = fs.createReadStream(String(logfile));
         var out = fs.createWriteStream(logfile + '.gz');
-
-        inp.pipe(gzip).pipe(out);
-        fs.unlinkSync(String(logfile));
+        
+        inp.pipe(gzip).pipe(out).on('finish', function() {
+          
+          // Don't try to unlink the file until after it has been compressed.
+          fs.unlinkSync(String(logfile));
+        });
+        
       }
     }
 


### PR DESCRIPTION
I have been encountering log rotation crashes mentioned in issue #9 almost constantly on my production server. While working through the issue, I have come to believe the cause is a race condition in the compressFile function. The file to be archived is opened for read and them piped into the compressor. This pipe is an asynchronous action. Right after that, the file is unlinked. I believe there is a race condition between the unlinking and the openning for compression. If the file is not opened before the unlink occurs, the unlink will delete the file. This in turn causes the failure to open because the file is gone.

After doing some reading about the pipe and unlink functions, I am proposing this fix.
If you wait to unlink until the pipe finishes, the race condition is gone. This fix has cleared up the issue on my production server.

