### PR TITLE
need to use moment to set a timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The DailyRotateFile transport can rotate files by minute, hour, day, month, year
 * __prepend:__ Defines if the rolling time of the log file should be prepended at the beginning of the filename (default 'false').
 * __localTime:__ A boolean to define whether time stamps should be local (default 'false' means that UTC time will be used).
 * __zippedArchive:__ A boolean to define whether or not to gzip archived log files (default 'false').
+* __timezone:__ A string to set your timezone (we use 'moment-timezone' to due with timezone, if you don't set this value, we will use Moment.tz.guess() by default).
 
 Valid meta characters in the datePattern are:
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var Stream = require('stream').Stream;
 var os = require('os');
 var winston = require('winston');
 var zlib = require('zlib');
+var Moment = require('moment-timezone');
 
 var weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -80,6 +81,7 @@ var DailyRotateFile = module.exports = function (options) {
   this.prepend = options.prepend || false;
   this.localTime = options.localTime || false;
   this.zippedArchive = options.zippedArchive || false;
+  this.timezone = options.timezone || Moment.tz.guess();
 
   if (this.json) {
     this.stringify = options.stringify;
@@ -375,7 +377,7 @@ DailyRotateFile.prototype.query = function (options, callback) {
       return;
     }
 
-    var time = new Date(log.timestamp);
+    var time = Moment.tz(log.timestamp, this.timezone).toDate();
     if ((options.from && time < options.from) ||
       (options.until && time > options.until)) {
       return;
@@ -741,7 +743,7 @@ DailyRotateFile.prototype._filenameHasExpired = function () {
 // based on localTime config
 //
 DailyRotateFile.prototype._getTime = function (timeType) {
-  var now = new Date();
+  var now = new Moment().tz(this.timezone).toDate();
 
   if (this.localTime) {
     if (timeType === 'year') {

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
       "node": true,
       "mocha": true
     }
+  },
+  "dependencies": {
+    "moment-timezone": "^0.5.13"
   }
 }


### PR DESCRIPTION
I have meet this issue:
I have some task running in docker and this is my every logs first record:
{"@message":"hello world","@timestamp":"2017-08-18 08:00:00:114","@fields":{"level":"info"}}
because my timestamps setting is
```javascript
Moment.tz.setDefault('Asia/Shanghai');
timestamp: () => Moment().format('YYYY-MM-DD HH:mm:ss:SSS')
```
and the log file will not rotate before 8 AM because in node docker image, timezone is not 'Asia/Shanghai' so ```new Date().getDay()``` is still yesterday and don't rotate the log file.
So, I really need this options to set logs timezone.