### PR TITLE
 update FileStreamRotator to use end vs destroy on WritableStream

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -84,7 +84,8 @@ var DailyRotateFile = function (options) {
             date_format: options.datePattern ? options.datePattern : 'YYYY-MM-DD',
             verbose: false,
             size: getMaxSize(options.maxSize),
-            max_logs: options.maxFiles
+            max_logs: options.maxFiles,
+            end_stream: true
         });
 
         this.logStream.on('rotate', function (oldFile, newFile) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -558,11 +558,11 @@
       }
     },
     "file-stream-rotator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.2.1.tgz",
-      "integrity": "sha1-DW/qGpp6uiWofP0xtuJp5E6PCvI=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.3.0.tgz",
+      "integrity": "sha512-8zQOBMOagg1U0slZ44zLtmo3Fh6NdzxoQuLPapLDMLH8cTrdTrP5XkqJyXlf/Ys68rf+XmySfyrd3cA9fZ9pxg==",
       "requires": {
-        "moment": "2.20.1"
+        "moment": "^2.11.2"
       }
     },
     "flat-cache": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rimraf": "2.5.2"
   },
   "dependencies": {
-    "file-stream-rotator": "^0.2.1",
+    "file-stream-rotator": "^0.3.0",
     "semver": "^5.5.0",
     "triple-beam": "^1.3.0",
     "winston-compat": "^0.1.4",


### PR DESCRIPTION
This is currently using my fork as a proof-of-concept. A PR was submitted to the package owner. I'll update this PR when the package owner publishes an updated FileStreamRotator package. 

Meanwhile, I've opened this so that users affected by #135, #142, and #147 can try to `npm install winstonjs/winston-daily-rotate-file#fix-file-errors` to see if this addresses the issue.