### PR TITLE
add check to determine whether log should be written

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -129,8 +129,16 @@ if (semver.major(winston.version) === 2) {
     DailyRotateFile.prototype.log = function (info, callback) {
         callback = callback || noop;
 
+        var self = this;
+        setImmediate(function () {
+            self.emit('logged', info);
+        });
+
+        if (!info) {
+            return callback ? callback() : false;
+        }
+
         this.logStream.write(info[MESSAGE] + this.options.eol);
-        this.emit('logged', info);
         callback(null, true);
     };
 }


### PR DESCRIPTION
Attempts to resolve #158. 

@indexzero can you please confirm that `winston@2` did not have an equivalent method to filter log messages (e.g., returning false from a format method)? I found a formatter property, but I dont believe is intended to do the same as the format methods in `winston@3`.
