### PR TITLE
export the interfaces along with class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,9 @@
-declare module "winston-daily-rotate-file" {
-    import * as Transport from "winston-transport";
+import * as Transport from "winston-transport";
+
+declare class DailyRotateFile implements DailyRotateFileTransportInstance {
+}
+
+declare namespace DailyRotateFile {
 
     interface DailyRotateFileTransportOptions extends Transport.TransportStreamOptions {
         json?: boolean;
@@ -54,8 +58,6 @@ declare module "winston-daily-rotate-file" {
 
         new (options?: DailyRotateFileTransportOptions): DailyRotateFileTransportInstance;
     }
-
-    const DailyRotateFile: DailyRotateFileTransportInstance;
-
-    export = DailyRotateFile;
 }
+
+export = DailyRotateFile;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import * as Transport from 'winston-transport';
 declare namespace DailyRotateFile {
     interface DailyRotateFileTransportOptions extends Transport.TransportStreamOptions {
       json?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,63 +1,56 @@
-import * as Transport from "winston-transport";
-
-declare class DailyRotateFile implements DailyRotateFileTransportInstance {
-}
-
 declare namespace DailyRotateFile {
-
     interface DailyRotateFileTransportOptions extends Transport.TransportStreamOptions {
-        json?: boolean;
-        eol?: string;
-
-        /**
-         * A string representing the moment.js date format to be used for rotating. The meta characters used in this string will dictate the frequency of the file rotation. For example, if your datePattern is simply 'HH' you will end up with 24 log files that are picked up and appended to every day. (default 'YYYY-MM-DD')
-         */
-        datePattern?: string;
-
-        /**
-         * A boolean to define whether or not to gzip archived log files. (default 'false')
-         */
-        zippedArchive?: boolean;
-
-        /**
-         * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
-         */
-        filename?: string;
-
-        /**
-         * The directory name to save log files to. (default: '.')
-         */
-        dirname?: string;
-
-        /**
-         * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
-         */
-        stream?: NodeJS.WritableStream;
-
-        /**
-         * Maximum size of the file after which it will rotate. This can be a number of bytes, or units of kb, mb, and gb. If using the units, add 'k', 'm', or 'g' as the suffix. The units need to directly follow the number. (default: null)
-         */
-        maxSize?: string | number;
-
-        /**
-         * Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null)
-         */
-        maxFiles?: string | number;
-
-        /**
-         * An object resembling https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options indicating additional options that should be passed to the file stream. (default: `{ flags: 'a' }`)
-         */
-        options?: string | object;
+      json?: boolean;
+      eol?: string;
+  
+      /**
+       * A string representing the moment.js date format to be used for rotating. The meta characters used in this string will dictate the frequency of the file rotation. For example, if your datePattern is simply 'HH' you will end up with 24 log files that are picked up and appended to every day. (default 'YYYY-MM-DD')
+       */
+      datePattern?: string;
+  
+      /**
+       * A boolean to define whether or not to gzip archived log files. (default 'false')
+       */
+      zippedArchive?: boolean;
+  
+      /**
+       * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
+       */
+      filename?: string;
+  
+      /**
+       * The directory name to save log files to. (default: '.')
+       */
+      dirname?: string;
+  
+      /**
+       * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
+       */
+      stream?: NodeJS.WritableStream;
+  
+      /**
+       * Maximum size of the file after which it will rotate. This can be a number of bytes, or units of kb, mb, and gb. If using the units, add 'k', 'm', or 'g' as the suffix. The units need to directly follow the number. (default: null)
+       */
+      maxSize?: string | number;
+  
+      /**
+       * Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null)
+       */
+      maxFiles?: string | number;
+  
+      /**
+       * An object resembling https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options indicating additional options that should be passed to the file stream. (default: `{ flags: 'a' }`)
+       */
+      options?: string | object;
     }
-
-    interface DailyRotateFileTransportInstance extends Transport {
-        filename: string;
-        dirname: string;
-        logStream: NodeJS.WritableStream;
-        options: DailyRotateFileTransportOptions;
-
-        new (options?: DailyRotateFileTransportOptions): DailyRotateFileTransportInstance;
-    }
-}
-
-export = DailyRotateFile;
+  }
+  
+  declare class DailyRotateFile extends Transport {
+    filename: string;
+    dirname: string;
+    logStream: NodeJS.WritableStream;
+    options: DailyRotateFile.DailyRotateFileTransportOptions;
+    constructor (options?: DailyRotateFile.DailyRotateFileTransportOptions);
+  }
+  
+  export = DailyRotateFile;


### PR DESCRIPTION
Creating a PR following a discussion on this issue: https://github.com/winstonjs/winston-daily-rotate-file/issues/121

It would be nice to export the interfaces as well, so that we can create proper objects in consuming typescript projects along with type definitions.