### PR TITLE
set the algorithm to `passthrough` implicitly.

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -87,7 +87,7 @@ var DailyRotateFile = function (options) {
             size: getMaxSize(options.maxSize),
             max_logs: options.maxFiles,
             end_stream: true,
-            audit_file: path.join(self.dirname, '.' + hash(options) + '-audit.json'),
+            audit_file: path.join(self.dirname, '.' + hash(options, { algorithm: 'passthrough' }) + '-audit.json'),
             file_options: options.options ? options.options : {flags: 'a'}
         });
 


### PR DESCRIPTION
Hi,
When I am using the package, it will throw an error

> Error: Algorithm "sha1"  not supported. supported values: passthrough

