### PR TITLE
Correct transport name in Transports interface.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ type RequireOnlyOne<T, Keys extends keyof T = keyof T> =
 // merging into winston.transports
 declare module 'winston/lib/winston/transports' {
     interface Transports {
-        DailyRotateFileTransport: typeof DailyRotateFile;
+        DailyRotateFile: typeof DailyRotateFile;
         DailyRotateFileTransportOptions: DailyRotateFile.DailyRotateFileTransportOptions;
     }
 }


### PR DESCRIPTION
When using TypeScript with the code:
new winston.transports.DailyRotateFile
We get the type check error:
Property 'DailyRotateFile' does not exist on type 'Transports'.

Viewed another way, it fixes the code completion of:
winston.transports.DailyRotateFileTransport
Which gives the runtime error:
winston.transports.DailyRotateFileTransport is not a constructor
(as reported in: https://github.com/winstonjs/winston-daily-rotate-file/issues/250#issue-516097180)