### PR TITLE
chore: update object-hash to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1148,9 +1148,9 @@
       "dev": true
     },
     "object-hash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
-      "integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+      "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
     },
     "object-keys": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "file-stream-rotator": "^0.5.5",
-    "object-hash": "^1.3.0",
+    "object-hash": "^2.0.1",
     "triple-beam": "^1.3.0",
     "winston-transport": "^4.2.0"
   }


### PR DESCRIPTION
changelog for `object-hash 2.0.0`
>v2.0.0
Only Node.js versions >= 6.0.0 are being tested in CI now. No other breaking changes were introduced.

v2.0.1 fixes: https://github.com/puleos/object-hash/issues/71

what i have done:
i am using vue-cli-plugin-electron-builder to build my electron appliaction and using this wonderful lib for logging purpose .

`eslint-loader(2.2.1)` and `winston-daily-rotate-file(4.3.0)` use `object-hash 1.3.1`, but i am stuck by issue https://github.com/puleos/object-hash/issues/71

so i manually replaced `node_modules/object-hash/dist/object_hash.js` with  the latest version(2.0.1)  and it works well.