### PR TITLE
Add try-catch for concurrency isue on rotate time

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -128,6 +128,7 @@ var DailyRotateFile = function (options) {
                     try {
                         fs.unlinkSync(oldFile);
                     } catch (err) {
+                        // assume already deleted
                     }
                     self.emit('archive', oldFile + '.gz');
                 });

--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -125,7 +125,10 @@ var DailyRotateFile = function (options) {
                 var inp = fs.createReadStream(oldFile);
                 var out = fs.createWriteStream(oldFile + '.gz');
                 inp.pipe(gzip).pipe(out).on('finish', function () {
-                    fs.unlinkSync(oldFile);
+                    try {
+                        fs.unlinkSync(oldFile);
+                    } catch (err) {
+                    }
                     self.emit('archive', oldFile + '.gz');
                 });
             });


### PR DESCRIPTION
I also got an error report with the folliwing exception:

```
2020-01-19 00:00:00.142  - [31merror[39m: host.iobroker-master Error: ENOENT: no such file or directory, unlink '/opt/iobroker/log/iobroker.2020-01-18.log'
    at Object.unlinkSync (fs.js:956:3)
    at WriteStream.<anonymous> (/opt/iobroker/node_modules/winston-daily-rotate-file/daily-rotate-file.js:128:24)
    at WriteStream.emit (events.js:203:15)
    at finishMaybe (_stream_writable.js:646:14)
    at stream._final (_stream_writable.js:624:5)
    at WriteStream._final (internal/fs/streams.js:268:3)
    at callFinal (_stream_writable.js:617:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

This also seems to be an concurrency issue when gz'ing the file. This is a very minimal fix for this issue. Question is also if emitting the signar on exception makes sense or if this line should also go into the try-catch. @mattberther What do you think?

I have no idea how we could prevent the root cause to happen beuase there are already two checks. I have also no idea if the packed file is still valid and readable when two processes do it in parallel ;-)

Maybe to avoid concurrency topic it should pack to a "temporary" (random) file and once done rename that to the final ".gz" one?! 