### PR TITLE
Make import explicit in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The DailyRotateFile transport can rotate files by minute, hour, day, month, year
 ## Usage
 ``` js
   var winston = require('winston');
-  require('winston-daily-rotate-file');
+  var DailyRotateFile = require('winston-daily-rotate-file');
 
-  var transport = new (winston.transports.DailyRotateFile)({
+  var transport = new DailyRotateFile({
     filename: 'application-%DATE%.log',
     datePattern: 'YYYY-MM-DD-HH',
     zippedArchive: true,


### PR DESCRIPTION
Without an explicit import of the constructor, and when using es modules in Typescript this throws 
```javascript
Property 'DailyRotateFile' does not exist on type 'Transports'.
```