### PR TITLE
feat: simplify options type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,5 @@
 import TransportStream = require("winston-transport");
 
-// referenced from https://stackoverflow.com/questions/40510611/typescript-interface-require-one-of-two-properties-to-exist
-type RequireOnlyOne<T, Keys extends keyof T = keyof T> =
-    Pick<T, Exclude<keyof T, Keys>>
-    & {
-        [K in Keys]-?:
-            Required<Pick<T, K>>
-            & Partial<Record<Exclude<Keys, K>, undefined>>
-    }[Keys];
-
 // merging into winston.transports
 declare module 'winston/lib/winston/transports' {
     interface Transports {
@@ -18,7 +9,7 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = RequireOnlyOne<GeneralDailyRotateFileTransportOptions, 'filename' | 'stream'>;
+    type DailyRotateFileTransportOptions = FilenameOptions | StreamOptions;
 
     interface GeneralDailyRotateFileTransportOptions extends TransportStream.TransportStreamOptions {
         json?: boolean;
@@ -35,19 +26,9 @@ declare namespace DailyRotateFile {
         zippedArchive?: boolean;
 
         /**
-         * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
-         */
-        filename?: string;
-
-        /**
          * The directory name to save log files to. (default: '.')
          */
         dirname?: string;
-
-        /**
-         * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
-         */
-        stream?: NodeJS.WritableStream;
 
         /**
          * Maximum size of the file after which it will rotate. This can be a number of bytes, or units of kb, mb, and gb. If using the units, add 'k', 'm', or 'g' as the suffix. The units need to directly follow the number. (default: null)
@@ -93,6 +74,20 @@ declare namespace DailyRotateFile {
          * The name of the tailable symlink. (default: 'current.log')
          */
         symlinkName?: string;
+    }
+
+    interface FilenameOptions extends GeneralDailyRotateFileTransportOptions {
+        /**
+         * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
+         */
+        filename?: string;
+    }
+
+    interface StreamOptions extends GeneralDailyRotateFileTransportOptions {
+        /**
+         * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
+         */
+        stream?: NodeJS.WritableStream;
     }
 }
 


### PR DESCRIPTION
Per an updated comment on the stackoverflow post in the diff, it is simpler to define this with two interfaces. This makes the type much easier to understand.