### PR TITLE
Prevent crash when file can not be unlinked

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -105,7 +105,16 @@ var DailyRotateFile = function (options) {
             if (options.zippedArchive) {
                 var gzName = params.name + '.gz';
                 if (fs.existsSync(gzName)) {
-                    fs.unlinkSync(gzName);
+                    try {
+                        fs.unlinkSync(gzName);
+                    }
+                    catch (_err) {
+                        // file is there but we got an error when trying to delete,
+                        // so permissions problem or concurrency issue and another
+                        // process already deleted it we could detect the concurrency
+                        // issue by checking err.type === ENOENT or EACCESS for
+                        // permissions ... but then?
+                    }
                     self.emit('logRemoved', gzName);
                     return;
                 }


### PR DESCRIPTION
There can be cases like prmission problems or "concurrency issues" where the existsSync check return true but the file can not be deleted. This crashes the application right now.

see https://sentry.iobroker.net/share/issue/18883926e035435a8ac6709b116b9a65/ for one example

```
Error: ENOENT: no such file or directory, unlink '/opt/iobroker/log/iobroker.2020-04-28.log.gz'
  File "fs.js", line 1053, col 3, in Object.unlinkSync
  File "/opt/iobroker/node_modules/winston-daily-rotate-file/daily-rotate-file.js", line 108, col 24, in EventEmitter.<anonymous>
    fs.unlinkSync(gzName);
  File "events.js", line 310, col 20, in EventEmitter.emit
  File "domain.js", line 482, col 12, in EventEmitter.emit
  File "/opt/iobroker/node_modules/file-stream-rotator/FileStreamRotator.js", line 387, col 24, in null.<anonymous>
    stream.emit("logRemoved", file)
  ?, in Array.filter
  File "/opt/iobroker/node_modules/file-stream-rotator/FileStreamRotator.js", line 382, col 43, in Object.FileStreamRotator.addLogToAudit
    var recentFiles = audit.files.filter(function(file){
  File "/opt/iobroker/node_modules/file-stream-rotator/FileStreamRotator.js", line 542, col 36, in EventEmitter.<anonymous>
    stream.auditLog = self.addLogToAudit(newLog,stream.auditLog, stream, self.verbose)
  File "events.js", line 322, col 22, in EventEmitter.emit
  File "domain.js", line 482, col 12, in EventEmitter.emit
```

This PR at least catches (and ignores) that possible error. For handling the question is what should happen? I personally would ignore it for now