### PR TITLE
filter logs by level when query

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -297,7 +297,9 @@ DailyRotateFile.prototype.query = function (options, callback) {
                 }
 
                 var time = new Date(log.timestamp);
-                if ((options.from && time < options.from) || (options.until && time > options.until)) {
+                if ((options.from && time < options.from) ||
+                    (options.until && time > options.until) ||
+                    (options.level && options.level !== log.level)) {
                     return;
                 }
 


### PR DESCRIPTION
When querying logs using Logger.query(options, callback), it is not filtering logs by level when options.level is added. I added a condition to filter logs by level too.