### PR TITLE
Restructure TypeScript declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The DailyRotateFile transport can rotate files by minute, hour, day, month, year
 * **frequency:** A string representing the frequency of rotation. This is useful if you want to have timed rotations, as opposed to rotations that happen at specific moments in time. Valid values are '#m' or '#h' (e.g., '5m' or '3h'). Leaving this null relies on `datePattern` for the rotation times. (default: null)
 * **datePattern:** A string representing the [moment.js date format](http://momentjs.com/docs/#/displaying/format/) to be used for rotating. The meta characters used in this string will dictate the frequency of the file rotation. For example, if your datePattern is simply 'HH' you will end up with 24 log files that are picked up and appended to every day. (default: 'YYYY-MM-DD')
 * **zippedArchive:** A boolean to define whether or not to gzip archived log files. (default: 'false')
-* **filename:** Filename to be used to log to. This filename can include the `%DATE%` placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
+* **filename:** Filename to be used to log to. This filename can include the `%DATE%` placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%')
 * **dirname:** The directory name to save log files to. (default: '.')
 * **stream:** Write directly to a custom stream and bypass the rotation capabilities. (default: null)
 * **maxSize:** Maximum size of the file after which it will rotate. This can be a number of bytes, or units of kb, mb, and gb. If using the units, add 'k', 'm', or 'g' as the suffix. The units need to directly follow the number. (default: null)

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | (GeneralDailyRotateFileTransportOptions & OptionsWithFilename) | (GeneralDailyRotateFileTransportOptions & OptionsWithStream)
+    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | OptionsWithFilename | OptionsWithStream;
 
     interface OptionsWithFilename extends GeneralDailyRotateFileTransportOptions {
         /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace DailyRotateFile {
         /**
          * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
          */
-        filename?: string;
+        filename: string;
 
         /**
          * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
@@ -32,7 +32,7 @@ declare namespace DailyRotateFile {
         /**
          * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
          */
-        stream?: NodeJS.WritableStream;
+        stream: NodeJS.WritableStream;
     }
 
     interface GeneralDailyRotateFileTransportOptions extends TransportStream.TransportStreamOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,14 @@
 import TransportStream = require("winston-transport");
 
+// referenced from https://stackoverflow.com/questions/40510611/typescript-interface-require-one-of-two-properties-to-exist
+type RequireOnlyOne<T, Keys extends keyof T = keyof T> =
+    Pick<T, Exclude<keyof T, Keys>>
+    & {
+        [K in Keys]-?:
+            Pick<T, K>
+            & Partial<Record<Exclude<Keys, K>, undefined>>
+    }[Keys];
+
 // merging into winston.transports
 declare module 'winston/lib/winston/transports' {
     interface Transports {
@@ -9,31 +18,7 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | OptionsWithFilename | OptionsWithStream;
-
-    interface OptionsWithFilename extends GeneralDailyRotateFileTransportOptions {
-        /**
-         * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
-         */
-        filename: string;
-
-        /**
-         * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
-         */
-        stream?: never;
-    }
-
-    interface OptionsWithStream extends GeneralDailyRotateFileTransportOptions {
-        /**
-         * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
-         */
-        filename?: never;
-
-        /**
-         * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
-         */
-        stream: NodeJS.WritableStream;
-    }
+    type DailyRotateFileTransportOptions = RequireOnlyOne<GeneralDailyRotateFileTransportOptions, 'filename' | 'stream'>;
 
     interface GeneralDailyRotateFileTransportOptions extends TransportStream.TransportStreamOptions {
         json?: boolean;
@@ -50,9 +35,19 @@ declare namespace DailyRotateFile {
         zippedArchive?: boolean;
 
         /**
+         * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
+         */
+        filename?: string;
+
+        /**
          * The directory name to save log files to. (default: '.')
          */
         dirname?: string;
+
+        /**
+         * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
+         */
+        stream?: NodeJS.WritableStream;
 
         /**
          * Maximum size of the file after which it will rotate. This can be a number of bytes, or units of kb, mb, and gb. If using the units, add 'k', 'm', or 'g' as the suffix. The units need to directly follow the number. (default: null)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1376,9 +1376,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -1393,9 +1393,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1743,11 +1743,11 @@
       }
     },
     "winston-transport": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
-      "integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
       "requires": {
-        "readable-stream": "^2.3.6",
+        "readable-stream": "^2.3.7",
         "triple-beam": "^1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "file-stream-rotator": "^0.5.7",
     "object-hash": "^2.0.1",
     "triple-beam": "^1.3.0",
-    "winston-transport": "^4.2.0"
+    "winston-transport": "^4.4.0"
   }
 }


### PR DESCRIPTION
In an attempt to resolve #305, this change should support the following:

- Create DailyRotateFileTransportOptions, passing neither a filename nor a stream (defaults to filename of winston.log.%DATE%)
- Create DailyRotateFileTransportOptions, passing a filename (will not allow passing a stream)
- Create DailyRotateFileTransportOptions, passing a stream (will not allow passing a filename)
