### PR TITLE
Remove unnecessary intersection type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | (GeneralDailyRotateFileTransportOptions & OptionsWithFilename) | (GeneralDailyRotateFileTransportOptions & OptionsWithStream)
+    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | OptionsWithFilename | OptionsWithStream;
 
     interface OptionsWithFilename extends GeneralDailyRotateFileTransportOptions {
         /**


### PR DESCRIPTION
Remove unnecessary intersection type from `DailyRotateFileTransportOptions` type definition. Since `OptionsWithFilename` and `OptionsWithStream` already both extend `GeneralDailyRotateFileTransportOptions`, they both contain all the member of `GeneralDailyRotateFileTransportOptions`, and there is no need to intersect them.