### PR TITLE
305 ts default options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | (GeneralDailyRotateFileTransportOptions & OptionsWithFilename) | (GeneralDailyRotateFileTransportOptions & OptionsWithStream)
+    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | OptionsWithFilename | OptionsWithStream;
 
     interface OptionsWithFilename extends GeneralDailyRotateFileTransportOptions {
         /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import TransportStream = require("winston-transport");
 
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
-type NAND<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
+type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
 
 // merging into winston.transports
 declare module 'winston/lib/winston/transports' {
@@ -12,7 +12,7 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = NAND<GeneralDailyRotateFileTransportOptions, NAND<OptionsWithFilename, OptionsWithStream>>;
+    type DailyRotateFileTransportOptions = XOR<GeneralDailyRotateFileTransportOptions, XOR<OptionsWithFilename, OptionsWithStream>>;
 
     interface OptionsWithFilename extends GeneralDailyRotateFileTransportOptions {
         /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = NAND<OptionsWithFilename, OptionsWithStream>;
+    type DailyRotateFileTransportOptions = NAND<GeneralDailyRotateFileTransportOptions, NAND<OptionsWithFilename, OptionsWithStream>>;
 
     interface OptionsWithFilename extends GeneralDailyRotateFileTransportOptions {
         /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
 import TransportStream = require("winston-transport");
 
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type NAND<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
+
 // merging into winston.transports
 declare module 'winston/lib/winston/transports' {
     interface Transports {
@@ -9,26 +12,16 @@ declare module 'winston/lib/winston/transports' {
 }
 
 declare namespace DailyRotateFile {
-    type DailyRotateFileTransportOptions = GeneralDailyRotateFileTransportOptions | OptionsWithFilename | OptionsWithStream;
+    type DailyRotateFileTransportOptions = NAND<OptionsWithFilename, OptionsWithStream>;
 
     interface OptionsWithFilename extends GeneralDailyRotateFileTransportOptions {
         /**
          * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
          */
         filename?: string;
-
-        /**
-         * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
-         */
-        stream?: never;
     }
 
     interface OptionsWithStream extends GeneralDailyRotateFileTransportOptions {
-        /**
-         * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
-         */
-        filename?: never;
-
         /**
          * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
          */


### PR DESCRIPTION
New solution using custom NAND type. This has the following result:
![Capture](https://user-images.githubusercontent.com/8991581/110016124-84a3b200-7cd9-11eb-9f85-85bd0999c2a7.PNG)
`d` is an error because it provides both a `filename` and a `stream`. Meanwhile, `a`, `aa`, `b`, and `c` are all valid `DailyRotateFileTransportOptions` objects.