### PR TITLE
Exposing the watch_log from file-stream-rotator to allow the logfile to be recreated in case of accidental deletion

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -90,7 +90,8 @@ var DailyRotateFile = function (options) {
             utc: options.utc ? options.utc : false,
             extension: options.extension ? options.extension : '',
             create_symlink: options.createSymlink ? options.createSymlink : false,
-            symlink_name: options.symlinkName ? options.symlinkName : 'current.log'
+            symlink_name: options.symlinkName ? options.symlinkName : 'current.log',
+            watch_log: options.watchLog ? options.watchLog : false
         });
 
         this.logStream.on('new', function (newFile) {

--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -142,6 +142,12 @@ var DailyRotateFile = function (options) {
                 });
             });
         }
+
+        if (options.watchLog) {
+            this.logStream.on('addWatcher', (newFile) => {
+                self.emit('addWatcher', newFile);
+            })
+        }
     }
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,6 +94,11 @@ declare namespace DailyRotateFile {
          */
         symlinkName?: string;
 
+        /**
+         * Watch the current file being written to and recreate it in case of accidental deletion. (default: FALSE)
+         */
+        watchLog?: boolean;
+        
         handleRejections?: boolean;
     }
 }

--- a/test/transport-tests.js
+++ b/test/transport-tests.js
@@ -196,6 +196,26 @@ describe('winston/transports/daily-rotate-file', function () {
             });
         });
 
+        describe('when setting watchLog', function () {
+            it('should addWatcher to recreate log if deleted', function (done) {
+                var opts = Object.assign({}, options);
+                opts.watchLog = true;
+                this.transport = new DailyRotateFile(opts);
+
+                this.transport.on('addWatcher', (newFile) => { 
+                    expect(newFile).to.equal(filename);
+                    done()
+                });
+
+                this.transport.on('new', (newFile) => {
+                    expect(newFile).to.equal(filename);
+                });
+
+                sendLogItem(this.transport, 'info', 'First message to file');
+                this.transport.close();
+            });
+        });
+        
         describe('query', function () {
             it('should call callback when no files are present', function () {
                 this.transport.query(function (err, results) {

--- a/test/transport-tests.js
+++ b/test/transport-tests.js
@@ -120,7 +120,7 @@ describe('winston/transports/daily-rotate-file', function () {
         });
 
         it('should write to the file', function (done) {
-            this.transport.on('finish', function () {
+            const finishListener = () => {
                 var logEntries = fs.readFileSync(filename).toString().split('\n').slice(0, -1);
                 expect(logEntries.length).to.equal(1);
 
@@ -128,7 +128,11 @@ describe('winston/transports/daily-rotate-file', function () {
                 expect(logEntry.level).to.equal('info');
                 expect(logEntry.message).to.equal('this message should write to the file');
                 done();
-            });
+
+                this.transport.removeListener('finish', finishListener)
+            }
+
+            this.transport.on('finish', finishListener);
 
             sendLogItem(this.transport, 'info', 'this message should write to the file', {}, function (err, logged) {
                 expect(err).to.be.null;
@@ -182,14 +186,18 @@ describe('winston/transports/daily-rotate-file', function () {
 
                 this.transport = new DailyRotateFile(opts);
 
-                this.transport.on('finish', function () {
+                const finishListener = () => {
                     fs.readdir(logDir, function (err, files) {
                         expect(files.filter(function (file) {
                             return path.extname(file) === '.gz';
                         }).length).to.equal(1);
                         done();
                     });
-                });
+
+                    this.transport.removeListener('finish', finishListener)
+                }
+
+                this.transport.on('finish', finishListener);
                 sendLogItem(this.transport, 'info', randomString(1056));
                 sendLogItem(this.transport, 'info', randomString(1056));
                 this.transport.close();
@@ -215,7 +223,7 @@ describe('winston/transports/daily-rotate-file', function () {
                 this.transport.close();
             });
         });
-        
+
         describe('query', function () {
             it('should call callback when no files are present', function () {
                 this.transport.query(function (err, results) {
@@ -247,13 +255,16 @@ describe('winston/transports/daily-rotate-file', function () {
                 sendLogItem(this.transport, 'info', randomString(1056));
 
                 var self = this;
-                this.transport.on('finish', function () {
+                const finishListener = () => {
                     self.transport.query(function (err, results) {
                         expect(results).to.not.be.null;
                         expect(results.length).to.equal(4);
                         done();
                     });
-                });
+                    this.transport.removeListener('finish', finishListener)
+                }
+                
+                this.transport.on('finish', finishListener);
 
                 this.transport.close();
             });


### PR DESCRIPTION
Related to issue: https://github.com/winstonjs/winston/issues/705

- Added new unit test to check for 'addWatcher' event - all unit tests green
- Fixed other unit tests "Error: done() called multiple times" by removing listeners after event
- Manual test: with watch_log=true, the logfile is recreated on deletion but only once since the watchers are not readded
-- dependency on: https://github.com/rogerc/file-stream-rotator/pull/83 to allow continuous logfile deletion to be recreated


Reference: 
- `watch_log`      Watch the current file being written to and recreate it in case of accidental deletion. Defaults to 'FALSE'
- https://github.com/rogerc/file-stream-rotator/blob/d48e1ec847bd27bc7896462d0e56ba19f07c581e/FileStreamRotator.js#L58
- https://github.com/rogerc/file-stream-rotator/blob/d48e1ec847bd27bc7896462d0e56ba19f07c581e/FileStreamRotator.js#L552-L563