### PR TITLE
Pass 'audit_hash_type' option for getStream method

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -91,7 +91,8 @@ var DailyRotateFile = function (options) {
             extension: options.extension ? options.extension : '',
             create_symlink: options.createSymlink ? options.createSymlink : false,
             symlink_name: options.symlinkName ? options.symlinkName : 'current.log',
-            watch_log: options.watchLog ? options.watchLog : false
+            watch_log: options.watchLog ? options.watchLog : false,
+            audit_hash_type: options.auditHashType || 'sha256'
         });
 
         this.logStream.on('new', function (newFile) {

--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -92,7 +92,7 @@ var DailyRotateFile = function (options) {
             create_symlink: options.createSymlink ? options.createSymlink : false,
             symlink_name: options.symlinkName ? options.symlinkName : 'current.log',
             watch_log: options.watchLog ? options.watchLog : false,
-            audit_hash_type: options.auditHashType || 'sha256'
+            audit_hash_type: options.auditHashType ? options.auditHashType  : 'sha256'
         });
 
         this.logStream.on('new', function (newFile) {


### PR DESCRIPTION
Adding 'audit_hash_type' option while using <file-stream-rotator>.getStream to avoid unsupported digest method issue faced on SLES platform.
Please check the issue : https://github.com/winstonjs/winston-daily-rotate-file/issues/340