### PR TITLE
[fix] typo in description of  option in type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare namespace DailyRotateFile {
         options?: string | object;
 
         /**
-         * A string representing the name of the name of the audit file. (default: './hash-audit.json')
+         * A string representing the name of the audit file. (default: './hash-audit.json')
          */
         auditFile?: string;
 


### PR DESCRIPTION
This PRs corrects the description typo of ```auditFile``` option in type definition file.