### PR TITLE
Prevent crash in bad timing cases

### DIFF
--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -136,8 +136,12 @@ var DailyRotateFile = function (options) {
                 var inp = fs.createReadStream(oldFile);
                 var out = fs.createWriteStream(oldFile + '.gz');
                 inp.pipe(gzip).pipe(out).on('finish', function () {
-                    if (fs.existsSync(oldFile)) {
-                        fs.unlinkSync(oldFile);
+                    try {
+                        if (fs.existsSync(oldFile)) {
+                            fs.unlinkSync(oldFile);
+                        }
+                    } catch (err) {
+                        // ignore becauuse should only happen in bad timing cases
                     }
                     self.emit('archive', oldFile + '.gz');
                 });

--- a/daily-rotate-file.js
+++ b/daily-rotate-file.js
@@ -137,9 +137,7 @@ var DailyRotateFile = function (options) {
                 var out = fs.createWriteStream(oldFile + '.gz');
                 inp.pipe(gzip).pipe(out).on('finish', function () {
                     try {
-                        if (fs.existsSync(oldFile)) {
-                            fs.unlinkSync(oldFile);
-                        }
+                        fs.unlinkSync(oldFile);
                     } catch (err) {
                         // ignore becauuse should only happen in bad timing cases
                     }


### PR DESCRIPTION
Resolves error cases like

```
ENOENT: no such file or directory, unlink '/opt/iobroker/log/iobroker.2023-01-04.log'
Error: ENOENT: no such file or directory, unlink '/opt/iobroker/log/iobroker.2023-01-04.log'
    at Object.unlinkSync (node:fs:1767:3)
    at WriteStream.<anonymous> (/opt/iobroker/node_modules/winston-daily-rotate-file/daily-rotate-file.js:140:28)
    at WriteStream.emit (node:events:525:35)
    at WriteStream.emit (node:domain:489:12)
    at finish (node:internal/streams/writable:756:10)
    at finishMaybe (node:internal/streams/writable:741:9)
    at afterWrite (node:internal/streams/writable:506:3)
    at onwrite (node:internal/streams/writable:479:7)
    at node:internal/fs/streams:416:5
    at FSReqCallback.wrapper [as oncomplete] (node:fs:816:5)

```

In rare cases it can happen that with multiple processes the archiving is started several times and so the "cloanup" is than also triggered overlapping. And in rare cases it can happen that the existsSync returns true but then for delete the file is gone already. We already fixed several such topics in the past